### PR TITLE
first wordpress commit

### DIFF
--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: wordpress
+description: wordpress
+type: application
+
+version: 0.0.1
+appVersion: 5.8.2

--- a/charts/wordpress/templates/createdatabase.yaml
+++ b/charts/wordpress/templates/createdatabase.yaml
@@ -1,0 +1,62 @@
+# This pod/job must not be available to the user in production
+# It has root credentials for CloudSQL and can create dbs, users, grants
+# It's only here for development/proof of concept
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mysqlclient
+spec:
+  serviceAccountName: poc-k8s-sa
+  restartPolicy: Never
+  containers:
+  - name: mysqlclient
+    image: mysql
+    env:
+    - name: SQL_ROOT_USER
+      valueFrom:
+        secretKeyRef:
+          name: gcp-cloudsql
+          key: user
+    - name: SQL_ROOT_PASS
+      valueFrom:
+        secretKeyRef:
+          name: gcp-cloudsql
+          key: pass
+    - name: WORDPRESS_DB_HOST
+      valueFrom:
+        secretKeyRef:
+          name: wordpress-db
+          key: host
+    - name: WORDPRESS_DB_USER
+      valueFrom:
+        secretKeyRef:
+          name: wordpress-db
+          key: user
+    - name: WORDPRESS_DB_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: wordpress-db
+          key: password
+    - name: WORDPRESS_DB_NAME
+      valueFrom:
+        secretKeyRef:
+          name: wordpress-db
+          key: db
+    command:
+    - "/bin/sh"
+    - "-c"
+    - "sleep 30; echo \"[client]\" >> /root/.my.cnf; echo \"host=${WORDPRESS_DB_HOST}\" >> /root/.my.cnf; echo \"user=${SQL_ROOT_USER}\" >> /root/.my.cnf; echo \"password=${SQL_ROOT_PASS}\" >> /root/.my.cnf; mysql -e \"CREATE DATABASE IF NOT EXISTS ${WORDPRESS_DB_NAME};\"; mysql -e \"CREATE USER '${WORDPRESS_DB_USER}'@'%' IDENTIFIED BY '${WORDPRESS_DB_PASSWORD}';\"; mysql -e \"GRANT ALL PRIVILEGES ON ${WORDPRESS_DB_NAME}.* TO '${WORDPRESS_DB_USER}'@'%' IDENTIFIED BY '${WORDPRESS_DB_PASSWORD}';\"; mysql -e \"FLUSH PRIVILEGES;\"; while true; do sleep 86400; done"
+  - name: cloud-sql-proxy
+    image: gcr.io/cloudsql-docker/gce-proxy:latest
+    env:
+    - name: GCP_CLOUDSQL_CONNECTION_NAME
+      valueFrom:
+        secretKeyRef:
+          name: gcp-cloudsql
+          key: connection_name
+    command:
+    - "/cloud_sql_proxy"
+    - "-ip_address_types=PRIVATE"
+    - "-instances=jetstack-gke-335118:europe-west2:poc-sql=tcp:3306"
+    securityContext:
+      runAsNonRoot: true

--- a/charts/wordpress/templates/installobjectcache.yaml
+++ b/charts/wordpress/templates/installobjectcache.yaml
@@ -1,0 +1,55 @@
+# Convert this into a Job
+apiVersion: v1
+kind: Pod
+metadata:
+  name: objectcacheprovision
+spec:
+  serviceAccountName: poc-k8s-sa
+  restartPolicy: Never
+  volumes:
+  - name: nfsshare
+    persistentVolumeClaim:
+      claimName: wpdocroot
+  containers:
+  - name: objectcacheprovision
+    image: wordpress:php8.1-fpm
+    # This excessive command would obviously be built into a container if not for time pressures
+    command:
+    - "/bin/sh"
+    - "-c"
+    - "export DEBIAN_FRONTEND=noninteractive; apt update; apt install vim-tiny dnsutils less iputils-ping iproute2 libzstd-dev curl unzip default-mysql-client openssh-server redis-tools -y; useradd -m -s /bin/bash cwdev; mkdir -m 0700 /home/cwdev/.ssh/; chown cwdev: /home/cwdev/.ssh/; touch /home/cwdev/.ssh/authorized_keys; chmod 0600 /home/cwdev/.ssh/authorized_keys; chown cwdev: /home/cwdev/.ssh/authorized_keys; pecl install igbinary && docker-php-ext-enable igbinary; yes | pecl install redis && docker-php-ext-enable redis; curl -so /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar; chmod +x /usr/local/bin/wp; curl -o /tmp/redis-cache-pro.zip -sL https://objectcache.pro/plugin/redis-cache-pro.zip?token=e279430effe043b8c17d3f3c751c4c0846bc70c97f0eaaea766b4079001c; unzip -q /tmp/redis-cache-pro.zip -d /tmp/; mkdir -m 0755 -p /var/www/html/wp-content/mu-plugins/; cp /tmp/redis-cache-pro/stubs/mu-plugin.php /var/www/html/wp-content/mu-plugins/redis-cache-pro.php; cp -r /tmp/redis-cache-pro/ /var/www/html/wp-content/mu-plugins/; chown -R www-data: /var/www/html/wp-content/; rm -rf /tmp/redis-cache-pro.zip; rm -rf /tmp/redis-cache-pro; WP_REDIS_CONFIG='[ \"token\" => \"e279430effe043b8c17d3f3c751c4c0846bc70c97f0eaaea766b4079001c\", \"host\" => \"redis.default.svc.cluster.local\", \"port\" => \"6379\", \"database\" => \"1\", \"timeout\" => \"2.5\", \"read_timeout\" => \"2.5\", \"split_alloptions\" => true, \"async_flush\" => true, \"client\" => \"phpredis\", \"compression\" => \"zstd\", \"serializer\" => \"igbinary\", \"prefetch\" => true, \"debug\" => false, \"save_commands\" => false, ]'; wp --allow-root --path=/var/www/html/ config set --add --raw WP_REDIS_CONFIG \"${WP_REDIS_CONFIG}\"; wp --allow-root --path=/var/www/html/ config set --add --raw WP_REDIS_DISABLED false; sleep 30; wp --allow-root --path=/var/www/html/ redis enable --force; while true; do sleep 86400; done"
+    env:
+    - name: WORDPRESS_DB_HOST
+      valueFrom:
+        secretKeyRef:
+          name: wordpress-db
+          key: host
+    - name: WORDPRESS_DB_USER
+      valueFrom:
+        secretKeyRef:
+          name: wordpress-db
+          key: user
+    - name: WORDPRESS_DB_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: wordpress-db
+          key: password
+    - name: WORDPRESS_DB_NAME
+      valueFrom:
+        secretKeyRef:
+          name: wordpress-db
+          key: db
+    envFrom:
+    - configMapRef:
+        name: wordpress-options-configmap
+    volumeMounts:
+    - name: nfsshare
+      mountPath: /var/www/html/
+  - name: cloud-sql-proxy
+    image: gcr.io/cloudsql-docker/gce-proxy:latest
+    command:
+      - "/cloud_sql_proxy"
+      - "-ip_address_types=PRIVATE"
+      - "-instances=jetstack-gke-335118:europe-west2:poc-sql=tcp:3306"
+    securityContext:
+      runAsNonRoot: true

--- a/charts/wordpress/templates/redis.yaml
+++ b/charts/wordpress/templates/redis.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+    role: wp
+spec:
+  replicas: 1 # must not exceed 1
+  selector:
+    matchLabels:
+      app: redis
+      tier: admin
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: redis
+        tier: admin
+    spec:
+      containers:
+      - name: redis
+        image: redis:{{ .Values.redis.version }}
+        ports:
+        - containerPort: 6379
+          name: redis-svc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  ports:
+    - port: 6379
+      targetPort: 6379
+      name: redis-svc
+  selector:
+    app: redis
+    tier: admin
+  type: ClusterIP

--- a/charts/wordpress/templates/secrets.yaml
+++ b/charts/wordpress/templates/secrets.yaml
@@ -1,0 +1,22 @@
+# This secret must not be available to users in prod
+# It's only here for development/Proof of concept
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gcp-cloudsql
+type: Opaque
+stringData:
+  connection_name: "jetstack-gke-335118:europe-west2:poc-sql"
+  user: "root"
+  pass: "nLoybPaYa9yTHcCt"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wordpress-db
+type: Opaque
+stringData:
+  host: "127.0.0.1"
+  user: "wp-db-user"
+  password: "adqNv7HzmpYKrgqk"
+  db: "wpdb"

--- a/charts/wordpress/templates/sshd.yaml
+++ b/charts/wordpress/templates/sshd.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sshd
+  labels:
+    app: sshd
+    role: wp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sshd
+      tier: admin
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: sshd
+        tier: admin
+    spec:
+      serviceAccountName: poc-k8s-sa
+      volumes:
+      - name: nfsshare
+        persistentVolumeClaim:
+          claimName: wpdocroot
+      - name: ssh-user-conf-volume
+        secret:
+          secretName: ssh-user-conf-secret
+          items:
+          - key: "authorized_keys"
+            path: "authorized_keys"
+      containers:
+      - name: sshd
+        image: wordpress:php8.1-fpm
+        # This excessive command would obviously be built into a container if not for time pressures
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "export DEBIAN_FRONTEND=noninteractive; apt update; apt install vim-tiny dnsutils less iputils-ping iproute2 libzstd-dev curl unzip default-mysql-client openssh-server redis-tools -y; useradd -m -s /bin/bash cwdev; mkdir -m 0700 /home/cwdev/.ssh/; chown cwdev: /home/cwdev/.ssh/; touch /home/cwdev/.ssh/authorized_keys; chmod 0600 /home/cwdev/.ssh/authorized_keys; chown cwdev: /home/cwdev/.ssh/authorized_keys; pecl install igbinary && docker-php-ext-enable igbinary; yes | pecl install redis && docker-php-ext-enable redis; curl -so /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar; chmod +x /usr/local/bin/wp; mkdir -p /var/run/admin/; mkdir -p /run/sshd/; /usr/sbin/sshd -D"
+        env:
+        - name: WORDPRESS_DB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: wordpress-db
+              key: host
+        - name: WORDPRESS_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: wordpress-db
+              key: user
+        - name: WORDPRESS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: wordpress-db
+              key: password
+        - name: WORDPRESS_DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: wordpress-db
+              key: db
+        envFrom:
+        - configMapRef:
+            name: wordpress-options-configmap
+        volumeMounts:
+        - name: nfsshare
+          mountPath: /var/www/html/
+        - name: ssh-user-conf-volume
+          mountPath: /home/cwdev/.ssh/authorized_keys
+          subPath: authorized_keys
+        ports:
+        - containerPort: 22
+          name: sshd-svc
+      - name: cloud-sql-proxy
+        image: gcr.io/cloudsql-docker/gce-proxy:latest
+        command:
+          - "/cloud_sql_proxy"
+          - "-ip_address_types=PRIVATE"
+          - "-instances=jetstack-gke-335118:europe-west2:poc-sql=tcp:3306"
+        securityContext:
+          runAsNonRoot: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sshd
+  labels:
+    app: sshd
+spec:
+  ports:
+    - port: 22
+      targetPort: 22
+      name: sshd-svc
+  selector:
+    app: sshd
+    tier: admin
+  type: ClusterIP

--- a/charts/wordpress/templates/userconfig.yaml
+++ b/charts/wordpress/templates/userconfig.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ssh-user-conf-secret
+type: Opaque
+stringData:
+  authorized_keys: |
+    ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEAx1xj43/jhzCiwzZAxv2Jni9JUfOHkim4AZGdsG118 user@host
+#data:
+#  authorized_keys: |
+#    c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUVBeDF4ajQzL2poekNpd3paQXh2MkpuaTlKVWZPSGtpbTRBWkdkc0cxMTgganNASmV0Sm9leTIwCg==
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wordpress-options-configmap
+data:
+  WORDPRESS_CONFIG_EXTRA: |
+    define('WP_MEMORY_LIMIT', '64M');
+    @ini_set( 'upload_max_size', '64M' );
+    @ini_set( 'post_max_size', '64M');
+    @ini_set( 'max_execution_time', '300' );
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: php-options-configmap
+data:
+  custom.ini: |
+    session.save_handler = redis
+    session.save_path = "tcp://redis.default.svc.cluster.local:6379"

--- a/charts/wordpress/templates/wordpress.yaml
+++ b/charts/wordpress/templates/wordpress.yaml
@@ -1,0 +1,122 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: wpdocroot
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  nfs:
+    server: nfs-nfs-server-gcp.default.svc.cluster.local
+    path: "/"
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: wpdocroot
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress
+  labels:
+    app: wordpress
+    role: wp
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: wordpress
+      tier: frontend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wordpress
+        tier: frontend
+    spec:
+      serviceAccountName: poc-k8s-sa
+      volumes:
+      - name: wordpress-persistent-storage
+        persistentVolumeClaim:
+          claimName: wpdocroot
+      - name: php-options-volume
+        configMap:
+          name: php-options-configmap
+          items:
+          - key: "custom.ini"
+            path: "custom.ini"
+      containers:
+      - name: wordpress
+        image: wordpress:5.8.2-php8.0-apache
+        # This excessive command would obviously be built into a container if not for time pressures
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "export DEBIAN_FRONTEND=noninteractive; apt update; apt install libzstd-dev; pecl install igbinary && docker-php-ext-enable igbinary; yes | pecl install redis && docker-php-ext-enable redis; /usr/local/bin/docker-entrypoint.sh apache2; apache2-foreground"
+        env:
+        - name: WORDPRESS_DB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: wordpress-db
+              key: host
+        - name: WORDPRESS_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: wordpress-db
+              key: user
+        - name: WORDPRESS_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: wordpress-db
+              key: password
+        - name: WORDPRESS_DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: wordpress-db
+              key: db
+        envFrom:
+        - configMapRef:
+            name: wordpress-options-configmap
+        ports:
+        - containerPort: 80
+          name: wp-svc
+        volumeMounts:
+        - name: wordpress-persistent-storage
+          mountPath: /var/www/html
+        - name: php-options-volume
+          mountPath: /usr/local/etc/php/conf.d/custom.ini
+          subPath: custom.ini
+      - name: cloud-sql-proxy
+        image: gcr.io/cloudsql-docker/gce-proxy:latest
+        command:
+          - "/cloud_sql_proxy"
+          - "-ip_address_types=PRIVATE"
+          - "-instances=jetstack-gke-335118:europe-west2:poc-sql=tcp:3306"
+        securityContext:
+          runAsNonRoot: true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress
+  labels:
+    app: wordpress
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      name: wp-svc
+  selector:
+    app: wordpress
+    tier: frontend
+  type: ClusterIP

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -1,0 +1,2 @@
+redis:
+  version: latest


### PR DESCRIPTION
A very initial commit for the WordPress application lifecycle ([CC-84](https://cloudways.atlassian.net/jira/software/c/projects/CC/boards/14?modal=detail&selectedIssue=CC-84)), including:

- PV and PVC from the existing NFS server
- Secrets and Config
- A Redis deployment and service [CC-85](https://cloudways.atlassian.net/jira/software/c/projects/CC/boards/14?modal=detail&selectedIssue=CC-85)
- A pod to initialise the WordPress database
- A WordPress deployment and service
- An SSHD deployment and service, containing `wp-cli`, `mysql-client`, `redis-cli`, and the filesystem mounted to `/var/www/html`
- A pod to install the Object Cache Pro module

Although this is a Helm chart there's currently very little that's been templated. It's mostly hard-coded at the moment with the exception of Redis version, which was a requirement of CC-85.

The two pods that serve single purposes (creation of DB, and installation of caching module) are here to show how these requirements could be addressed but would not be implemented like this in production.

Note that `helm uninstall` will leave the PV and PVC in `terminating` status until the deletion protection is removed:
```
$ kubectl patch pvc wpdocroot -p '{"metadata":{"finalizers": []}}' --type=merge
```
The uninstall action will also not do anything to wipe the database or NFS content.